### PR TITLE
Fixed small bugs, Added helper functions

### DIFF
--- a/spriterengine/animation/animationinstance.h
+++ b/spriterengine/animation/animationinstance.h
@@ -28,11 +28,20 @@ namespace SpriterEngine
 		void findCurrentKeys(real newTime, bool forward);
 		void processCurrentKeys(real newTime, ObjectInterfaceVector **instanceZOrder);
 
+		std::string getName();
+
 		bool looping();
 
 		real length();
 
 		real currentTime();
+
+		int currentMainlineKeyIndex();
+
+		void setCurrentTimeToPreviousKeyFrame(ObjectInterfaceVector **instanceZOrder);
+		void setCurrentTimeToNextKeyFrame(ObjectInterfaceVector **instanceZOrder);
+		void setCurrentTimeToKeyAtIndex(int newIndex, ObjectInterfaceVector **instanceZOrder);
+
 
 		real processRefKeys(real newTime);
 		void blendRefKeys(real newTime, real blendRatio);
@@ -42,6 +51,8 @@ namespace SpriterEngine
 		void processCurrentTimelineKeys(real newTime);
 
 		void blendCurrentTimelineKeys(real newTime, real blendRatio);
+
+		int mainlineKeyCount();
 
 	private:
 		void findCurrentTimelineKeys(real newTime, bool forward);
@@ -57,7 +68,11 @@ namespace SpriterEngine
 		MainlineKeyInstanceVector mainlineKeys;
 		MainlineKeyInstanceVectorIterator mainlineKeyIterator;
 
+		MainlineKeyInstance *mainlineKeyAtIndex(int index);
+
 		TimelineInstanceVector timelines;
+
+		std::string name;
 
 		real animationLength;
 		bool isLooping;

--- a/spriterengine/entity/entityinstance.cpp
+++ b/spriterengine/entity/entityinstance.cpp
@@ -28,7 +28,8 @@ namespace SpriterEngine
 		blendCurrentTime(0),
 		blendTotalTime(0),
 		blendedAnimation(0),
-		isPlaying(true)
+		isPlaying(true),
+		justFinished(false)
 	{
 	}
 	EntityInstance::EntityInstance(SpriterModel *model, Entity *entity, CharacterMapInterface *initialCharacterMapInterface, ObjectFactory *objectFactory) :
@@ -43,7 +44,8 @@ namespace SpriterEngine
 		blendCurrentTime(0),
 		blendTotalTime(0),
 		blendedAnimation(0),
-		isPlaying(true)
+		isPlaying(true),
+		justFinished(false)
 	{
 		model->setupFileReferences(&files);
 		currentEntity = (*entities.insert(std::make_pair(entity->getId(), new EntityInstanceData(model, this, entity, objectFactory))).first).second;
@@ -65,6 +67,7 @@ namespace SpriterEngine
 
 	void EntityInstance::setTimeElapsed(real timeElapsed)
 	{
+		justFinished = false;
 		if (currentAnimation)
 		{
 			if (isPlaying)
@@ -72,10 +75,14 @@ namespace SpriterEngine
 				timeElapsed *= playbackSpeedRatio;
 				real newTime = getCurrentTime() + timeElapsed;
 				
-				if (!currentAnimation->looping() && newTime >= currentAnimation->length())
+				if (newTime >= currentAnimation->length())
 				{
-					isPlaying = false;
-					newTime = currentAnimation->length();
+					justFinished = true;
+					if (!currentAnimation->looping())
+					{
+						isPlaying = false;
+						newTime = currentAnimation->length();
+					}
 				}
 
 				if (blendedAnimation)
@@ -217,6 +224,37 @@ namespace SpriterEngine
 	real EntityInstance::getTimeRatio()
 	{
 		return getCurrentTime() / currentAnimation->length();
+	}
+
+	std::string EntityInstance::currentEntityName()
+	{
+		if (currentEntity)
+		{
+			return currentEntity->getName();
+		}
+		return "";
+	}
+
+	std::string EntityInstance::currentAnimationName()
+	{
+		if (currentAnimation)
+		{
+			return currentAnimation->getName();
+		}
+		return "";
+	}
+
+	int EntityInstance::animationCount()
+	{
+		if (currentEntity)
+		{
+			return currentEntity->animationCount();
+		}
+		else
+		{
+			Settings::error("EntityInstance::animationCount() - no current entity");
+			return 0;
+		}
 	}
 
 	VariableInstanceNameAndIdMap *EntityInstance::getVariables()
@@ -441,6 +479,31 @@ namespace SpriterEngine
 		}
 	}
 
+	void EntityInstance::setCurrentEntity(const std::string & newEntityName, const std::string & newAnimationName, SpriterModel * modelForAutoAppend)
+	{
+		for (auto& it : entities)
+		{
+			if (it.second->getName() == newEntityName)
+			{
+				setCurrentEntity(it.second);
+				if (!newAnimationName.empty())
+				{
+					setCurrentAnimation(newAnimationName);
+				}
+				else
+				{
+					setCurrentAnimation(0);
+				}
+				return;
+			}
+		}
+		if (modelForAutoAppend)
+		{
+			appendEntity(modelForAutoAppend, newEntityName);
+			setCurrentEntity(newEntityName, newAnimationName);
+		}
+	}
+
 	void EntityInstance::setCurrentAnimation(int newAnimationIndex)
 	{
 		currentEntity->setCurrentAnimation(newAnimationIndex, &currentAnimation);
@@ -450,6 +513,9 @@ namespace SpriterEngine
 	void EntityInstance::setCurrentAnimation(const std::string & animationName)
 	{
 		currentEntity->setCurrentAnimation(animationName, &currentAnimation);
+		blendedAnimation = 0;
+		blendCurrentTime = 0;
+		blendTotalTime = 0;
 		isPlaying = true;
 	}
 
@@ -469,6 +535,7 @@ namespace SpriterEngine
 
 	void EntityInstance::setCurrentTime(real newCurrentTime)
 	{
+		justFinished = false;
 		if (currentAnimation)
 		{
 			currentAnimation->findAndProcessKeys(newCurrentTime, newCurrentTime > getCurrentTime(), &zOrder);
@@ -481,12 +548,116 @@ namespace SpriterEngine
 
 	void EntityInstance::setTimeRatio(real newCurrentTimeRatio)
 	{
+		justFinished = false;
 		currentAnimation->findCurrentKeys(newCurrentTimeRatio * currentAnimation->length(), newCurrentTimeRatio >= inverseLinear(0, currentAnimation->length(), getCurrentTime()));
 	}
 
 	void EntityInstance::setPlaybackSpeedRatio(real newPlaybackSpeedRatio)
 	{
 		playbackSpeedRatio = newPlaybackSpeedRatio;
+	}
+
+	int EntityInstance::currentMainlineKeyIndex()
+	{
+		if (currentAnimation)
+		{
+			return currentAnimation->currentMainlineKeyIndex();
+		}
+		else
+		{
+			Settings::error("EntityInstance::currentMainlineKeyIndex - current animation not set");
+			return 0;
+		}
+	}
+
+	bool EntityInstance::animationJustFinished(bool orLooped)
+	{
+		if(currentAnimation)
+		{
+			if (orLooped || !currentAnimation->looping())
+			{
+				return justFinished;
+			}
+		}
+		else
+		{
+			Settings::error("EntityInstance::animationJustFinished - current animation not set");
+		}
+		return false;
+	}
+
+	bool EntityInstance::animationJustLooped()
+	{
+		if (currentAnimation)
+		{
+			if (currentAnimation->looping())
+			{
+				return justFinished;
+			}
+		}
+		else
+		{
+			Settings::error("EntityInstance::animationJustFinished - current animation not set");
+		}
+		return false;
+	}
+
+	void EntityInstance::setCurrentTimeToNextKeyFrame()
+	{
+		justFinished = false;
+		if (currentAnimation)
+		{
+			currentAnimation->setCurrentTimeToNextKeyFrame(&zOrder);
+		}
+		else
+		{
+			Settings::error("EntityInstance::setCurrentTimeToNextKeyFrame - current animation not set");
+		}
+	}
+
+	void EntityInstance::setCurrentTimeToPreviousKeyFrame()
+	{
+		justFinished = false;
+		if (currentAnimation)
+		{
+			currentAnimation->setCurrentTimeToPreviousKeyFrame(&zOrder);
+		}
+		else
+		{
+			Settings::error("EntityInstance::setCurrentTimeToPreviousKeyFrame - current animation not set");
+		}
+	}
+
+	void EntityInstance::setCurrentTimeToKeyAtIndex(int newKeyIndex)
+	{
+		justFinished = false;
+		if (currentAnimation)
+		{
+			currentAnimation->setCurrentTimeToKeyAtIndex(newKeyIndex, &zOrder);
+		}
+		else
+		{
+			Settings::error("EntityInstance::setCurrentTimeToKeyAtIndex - current animation not set");
+		}
+	}
+
+	UniversalObjectInterface *EntityInstance::objectIfExistsOnCurrentFrame(std::string objectName)
+	{
+		if (zOrder)
+		{
+			UniversalObjectInterface *object = getObjectInstance(objectName);
+			if (object)
+			{
+				for (auto& it : *zOrder)
+				{
+					if (it == object)
+					{
+						return object;
+					}
+				}
+			}
+		}
+		return 0;
 	}
 
 	void EntityInstance::applyCharacterMap(const std::string &mapName)
@@ -547,7 +718,11 @@ namespace SpriterEngine
 	{
 		model->setupFileReferences(&files);
 		EntityInstanceData *newEntityData = (*entities.insert(std::make_pair(entity->getId(), new EntityInstanceData(model, this, entity, objectFactory))).first).second;
-		entity->setupInstance(model, this, newEntityData, objectFactory);
+	}
+
+	void EntityInstance::appendEntity(SpriterModel * model, std::string entityName)
+	{
+		model->appendEntityToInstanceByName(this, entityName);
 	}
 
 	EntityInstanceData * EntityInstance::getEntity(int entityId)

--- a/spriterengine/entity/entityinstance.h
+++ b/spriterengine/entity/entityinstance.h
@@ -54,6 +54,16 @@ namespace SpriterEngine
 		real getCurrentTime() override;
 		real getTimeRatio() override;
 
+		std::string currentEntityName();
+		std::string currentAnimationName();
+
+		int animationCount();
+
+		int currentMainlineKeyIndex();
+
+		bool animationJustFinished(bool orLooped = false);
+		bool animationJustLooped();
+
 		VariableInstanceNameAndIdMap *getVariables() override;
 		UniversalObjectInterface *getVariable(int variableId);
 		VariableInstanceNameAndIdMap *getVariables(int objectId);
@@ -94,6 +104,7 @@ namespace SpriterEngine
 
 		void setCurrentEntity(int newEntityIndex) override;
 		void setCurrentEntity(EntityInstanceData *newCurrentEntity) override;
+		void setCurrentEntity(const std::string & newEntityName, const std::string & newAnimationName = "", SpriterModel * modelForAutoAppend = 0);
 		void setCurrentAnimation(int newAnimationIndex) override;
 		void setCurrentAnimation(const std::string &animationName);
 		void setCurrentAnimation(const std::string &animationName, real blendTime);
@@ -102,6 +113,13 @@ namespace SpriterEngine
 		void setTimeRatio(real newCurrentTimeRatio) override;
 
 		void setPlaybackSpeedRatio(real newPlaybackSpeedRatio);
+
+		void setCurrentTimeToPreviousKeyFrame();
+		void setCurrentTimeToNextKeyFrame();
+		void setCurrentTimeToKeyAtIndex(int newKeyIndex);
+
+		UniversalObjectInterface *objectIfExistsOnCurrentFrame(std::string objectName);
+
 
 		void applyCharacterMap(const std::string &mapName);
 		void removeCharacterMap(const std::string &mapName);
@@ -116,6 +134,7 @@ namespace SpriterEngine
 		ObjectInterfaceVector *getZOrder() override;
 
 		void appendEntity(SpriterModel *model, Entity *entity, ObjectFactory *objectFactory);
+		void appendEntity(SpriterModel * model, std::string entityName);
 
 		EntityInstanceData *getEntity(int entityId) override;
 
@@ -137,6 +156,8 @@ namespace SpriterEngine
 		AnimationInstance *currentAnimation;
 
 		bool isPlaying;
+
+		bool justFinished;
 
 		AnimationInstance *blendedAnimation;
 		real blendTotalTime;

--- a/spriterengine/entity/entityinstancedata.cpp
+++ b/spriterengine/entity/entityinstancedata.cpp
@@ -22,6 +22,7 @@ namespace SpriterEngine
 	{
 		transformProcessor = &(*transformers.insert(std::make_pair(THIS_ENTITY, TransformProcessor(entityInstance))).first).second;
 		entity->setupInstance(model, entityInstance, this, objectFactory);
+		entityName = entity->getName();
 	}
 
 	EntityInstanceData::~EntityInstanceData()
@@ -427,6 +428,16 @@ namespace SpriterEngine
 	void EntityInstanceData::updateTransformProcessor()
 	{
 		transformProcessor->setTrigFunctions();
+	}
+
+	std::string EntityInstanceData::getName()
+	{
+		return entityName;
+	}
+
+	int EntityInstanceData::animationCount()
+	{
+		return animations.size();
 	}
 
 }

--- a/spriterengine/entity/entityinstancedata.h
+++ b/spriterengine/entity/entityinstancedata.h
@@ -94,7 +94,13 @@ namespace SpriterEngine
 
 		void updateTransformProcessor();
 
+		std::string getName();
+
+		int animationCount();
+
 	protected:
+		std::string entityName;
+
 		AnimationInstanceIdMap animations;
 		AnimationInstanceNameMap animationNameMap;
 

--- a/spriterengine/entity/object.cpp
+++ b/spriterengine/entity/object.cpp
@@ -144,7 +144,7 @@ namespace SpriterEngine
 			break;
 
 		case OBJECTTYPE_ENTITY:
-			entityInstanceData->setObjectInstance(objectId, name, model->getNewEntityInstance(&this->initializationIds));
+			entityInstanceData->setObjectInstance(objectId, name, model->getNewEntityInstance(&initializationIds));
 			break;
 
 		case OBJECTTYPE_SOUND:

--- a/spriterengine/model/spritermodel.cpp
+++ b/spriterengine/model/spritermodel.cpp
@@ -80,6 +80,26 @@ namespace SpriterEngine
 		return newEntityInstance;
 	}
 
+	void SpriterModel::appendEntityToInstanceByName(EntityInstance *entityInstance, std::string entityName)
+	{
+		if (entityInstance)
+		{
+			Entity *entity = getEntity(entityName);
+			if (entity)
+			{
+				entityInstance->appendEntity(this, entity, objectFactory);
+			}
+			else
+			{
+				Settings::error("SpriterModel::appendEntityToInstanceByName - no entityInstance provided \"" + entityName + "\"");
+			}
+		}
+		else
+		{
+			Settings::error("SpriterModel::appendEntityToInstanceByName - no entityInstance provided \"" + entityName + "\"");
+		}
+	}
+
 	EntityInstance * SpriterModel::getNewEntityInstance(std::string entityName)
 	{
 		for (auto& it : entities)
@@ -168,6 +188,19 @@ namespace SpriterEngine
 			Settings::error("SpriterModel::getEntity - entity id " + std::to_string(entityId) + " out of range");
 			return 0;
 		}
+	}
+
+	Entity * SpriterModel::getEntity(std::string entityName)
+	{
+		for (auto& it : entities)
+		{
+			if (it->getName() == entityName)
+			{
+				return it;
+			}
+		}
+		Settings::error("SpriterModel::getEntity - could not find entity with name \"" + entityName + "\"");
+		return 0;
 	}
 
 }

--- a/spriterengine/model/spritermodel.h
+++ b/spriterengine/model/spritermodel.h
@@ -34,6 +34,7 @@ namespace SpriterEngine
 		EntityInstance *getNewEntityInstance(int entityId);
 		EntityInstance *getNewEntityInstance(EntityIdVector *entityIds);
 		EntityInstance *getNewEntityInstance(std::string entityName);
+		void appendEntityToInstanceByName(EntityInstance * entityInstance, std::string entityName);
 		void setupFileReferences(FileReferenceVector *fileReferences);
 
 		Entity *pushBackEntity(std::string entityName);
@@ -60,6 +61,7 @@ namespace SpriterEngine
 		ObjectFactory *objectFactory;
 
 		Entity *getEntity(int entityId);
+		Entity *getEntity(std::string entityName);
 	};
 
 }

--- a/spriterengine/objectinfo/boxobjectinfo.cpp
+++ b/spriterengine/objectinfo/boxobjectinfo.cpp
@@ -3,7 +3,9 @@
 namespace SpriterEngine
 {
 
-	BoxObjectInfo::BoxObjectInfo()
+	BoxObjectInfo::BoxObjectInfo():
+		scale(1, 1),
+		alpha(1)
 	{
 	}
 
@@ -65,6 +67,7 @@ namespace SpriterEngine
 	void BoxObjectInfo::setObjectToLinear(UniversalObjectInterface *bObject, real t, UniversalObjectInterface *resultObject)
 	{
 		resultObject->setAngle(angle.angleLinear(bObject->getAngle(), t));
+		resultObject->setAlpha(linear(alpha , bObject->getAlpha(), t));
 		resultObject->setPosition(linear(position, bObject->getPosition(), t));
 		resultObject->setScale(linear(scale, bObject->getScale(), t));
 		resultObject->setPivot(pivot);


### PR DESCRIPTION
changed void EntityInstance::setCurrentAnimation(const std::string &
animationName) to stop any current blends

fixed a bug where entities appended after creation would add all
animations and objects to the new EntityInstanceData twice

added scale and alpha initialization to BoxObjectInfo

added alpha to BoxObjectInfo::setObjectToLinear

added the following functions:
std::string currentEntityName();
std::string currentAnimationName();
void EntityInstance::appendEntity(SpriterModel \* model, std::string
entityName)
void EntityInstance::setCurrentEntity(const std::string & newEntityName,
const std::string & newAnimationName, SpriterModel \* modelForAutoAppend)
UniversalObjectInstance
*EntityInstance::objectIfExistsInCurrentFrame(const std::string &
objectName)
EntityInstance::animationCount()
bool EntityInstance::animationJustFinished(bool orLooped = false)
void EntityInstance::setCurrentTimeToPreviousKeyFrame();
void EntityInstance::setCurrentTimeToNextKeyFrame();
void EntityInstance::setCurrentTimeToKeyAtIndex(int newKeyIndex);
int EntityInstance::currentMainlineKeyIndex();
